### PR TITLE
Count keywords doc

### DIFF
--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -1,45 +1,218 @@
 {
-    "cells": [
-        {
-            "cell_type": "markdown",
-            "source": [
-                "# Example usage\n",
-                "\n",
-                "To use `wordwright` in a project:"
-            ],
-            "metadata": {}
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "source": [
-                "import wordwright\n",
-                "\n",
-                "print(wordwright.__version__)"
-            ],
-            "outputs": [],
-            "metadata": {}
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.8.5"
-        }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 4
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example usage\n",
+    "\n",
+    "## `count_keywords`\n",
+    "\n",
+    "This is a function that counts keywords in a text. The user gets to specify the keywords (represented as a list of strings) to look for and the text (represented as a string object). For our demonstration, we will use the Unlimited Blade Works chant from the popular anime series Fate/Stay Night, with some adjustments to demonstrate the some features of the function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'my': 3, 'life': 1, 'pray': 1, \"i've\": 1}"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from wordwright.count_keywords import count_keywords\n",
+    "\n",
+    "ubw_chant = '''I am the Bone of my Sword.\n",
+    "               Steel is My Body and Fire is my Blood. \n",
+    "               I've created over a Thousand Blades, \n",
+    "               Unknown to Death, \n",
+    "               Nor known to Life. \n",
+    "               Have withstood Pain to create many Weapons.\n",
+    "               Yet those Hands will never hold Anything.\n",
+    "               So, as I Pray--\n",
+    "               Unlimited Blade Works.'''\n",
+    "count_keywords(ubw_chant, ['my', 'life', 'Pray', 'i\\'ve'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function counts these words correctly. Moreover, notice that it forces lower case and ignores punctuation, with the exception of the apostrophes used for sentence contraption. This is because our function first preprocesses the text and the keywords by forcing lower case and removing all punctuation except for the apostrophes when evaluating word counts. This includes cases where a hyphen is used to join two words (ex: to-do is treated as todo). These rules extend to both the text and the keywords:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{\"can't\": 1, 'todo': 2}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = 'I can\\'t seem to find the to-do list, cant you help me find the todo list?'\n",
+    "count_keywords(test, ['can\\'t', 'todo'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the word \"can't\" is treated as a separate word than \"cant\" (a count of 1), whereas \"to-do\" is treated as the same word as \"todo\" (a count of 2).\n",
+    "\n",
+    "If the user were to specify the same word multiple times, the output would only show the count for that word once. The position of this word in the output is determined by that of the word's first appearance in the keyword list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'find': 1, 'phone': 1}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = 'Where can I find a phone?'\n",
+    "count_keywords(test, ['find', 'phone', 'phonE!', 'phone'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another important thing is white space/punctuation only string. Because we evaluate word counts after preprocessing, our function treats these strings as empty:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'': 0}"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = 'abcdefg.'\n",
+    "count_keywords(test, [' ', '', '\\'-['])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that even with the presence of an apostrophe, if the string contains only punctuation, if will be treated as an empty string. And since all these three keywords are considered empty strings, the final output only shows the count for empty string once. This is also applicable for the text:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'': 0, 'a': 0, 'b': 0}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = '     /....,.!'\n",
+    "count_keywords(test, ['', 'a', 'b'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here the text itself contains only white spaces and punctuation, and therefore the function considers it an empty string, and the function evaluates all counts to be 0, including that of an empty string.\n",
+    "\n",
+    "Finally, a word trapped inside punctuation would be extracted and evaluated as is. This applies to both the text and keywords:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'you': 1}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test = '!y-o,u'\n",
+    "count_keywords(test, ['y.o.u!!!!!'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that the word \"you\" is trapped within punctuation, but our function takes the alphabets out and pieces the word together."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:573]",
+   "language": "python",
+   "name": "conda-env-573-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
 }

--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -8,7 +8,66 @@
     "\n",
     "## `count_keywords`\n",
     "\n",
-    "This is a function that counts keywords in a text. The user gets to specify the keywords (represented as a list of strings) to look for and the text (represented as a string object). For our demonstration, we will use the Unlimited Blade Works chant from the popular anime series Fate/Stay Night, with some adjustments to demonstrate the some features of the function."
+    "This is a function that counts keywords in a text. The user gets to specify the keywords to look for and the text."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'breathtaking': 2, 'exceptional': 3, \"city's\": 1}"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from wordwright.count_keywords import count_keywords\n",
+    "\n",
+    "# Long positive review of a city apartment\n",
+    "review1 = \"Our stay at Skyline Plaza was truly exceptional. \" + \\\n",
+    "          \"The apartment offered breathtaking views of the city skyline, \" + \\\n",
+    "          \"making every morning a luxurious experience. \" + \\\n",
+    "          \"Inside, modern amenities like a fully-equipped kitchen, \" + \\\n",
+    "          \"high-speed internet, and a smart TV provided exceptional comfort. \" + \\\n",
+    "          \"The spacious bedrooms, each with ultra-comfortable beds, \" + \\\n",
+    "          \"ensured restful nights after exploring the city's breathtaking sights. \" + \\\n",
+    "          \"Located at the heart of the city, the apartment's proximity to public transport, \" + \\\n",
+    "          \"diverse restaurants, and shops was incredibly convenient. \" + \\\n",
+    "          \"Our host was wonderfully accommodating, providing a detailed \" + \\\n",
+    "          \"city guide and personal recommendations for dining with views of the skyline. \" + \\\n",
+    "          \"For anyone seeking a mix of modern luxury and convenient city living, \" + \\\n",
+    "          \"this apartment is a perfect choice. Its luxurious amenities and prime \" + \\\n",
+    "          \"location make it a standout choice for an exceptional city experience.\"\n",
+    "\n",
+    "# Short positive review of a cozy cottage\n",
+    "review2 = \"Cozy Cottage was a quiet, charming escape from the busy city life. \" + \\\n",
+    "          \"The garden was delightful, and the location was quiet yet convenient. \" + \\\n",
+    "          \"A perfect weekend getaway! Highly recommend!\"\n",
+    "\n",
+    "# A medium length negative review \n",
+    "review3 = \"Although the location nestled right in the heart of the city, \" + \\\n",
+    "          \"our stay was marred by disappointment. The first sign of trouble \" + \\\n",
+    "          \"was the linens; they had a strange, unpleasant smell, as if they \" + \\\n",
+    "          \"hadn't been washed. The bathroom, too, has a strange odor that made \" + \\\n",
+    "          \"it feel unclean and unpleasant. Overall, the lack of cleanliness cast \" + \\\n",
+    "          \"a shadow over our visit, turning our stay into an unpleasant experience. \" + \\\n",
+    "          \"The location, unfortunately, couldn't make up for these  disappointing aspects.\"\n",
+    "\n",
+    "count_keywords(review1, ['breathtaking', 'exceptional', 'city\\'s'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function counts these words correctly. Moreover, notice that it forces lower case and ignores punctuation, with the exception of the apostrophes used for sentence contraption. This is because our function first preprocesses the text and the keywords by forcing lower case and removing all punctuation except for the apostrophes when evaluating word counts. This includes cases where a hyphen is used to join two words (ex: fully-equipped is treated as fullyequipped). These rules extend to both the text and the keywords:"
    ]
   },
   {
@@ -19,7 +78,7 @@
     {
      "data": {
       "text/plain": [
-       "{'my': 3, 'life': 1, 'pray': 1, \"i've\": 1}"
+       "{'fullyequipped': 1}"
       ]
      },
      "execution_count": 10,
@@ -28,169 +87,65 @@
     }
    ],
    "source": [
-    "from wordwright.count_keywords import count_keywords\n",
+    "count_keywords(review1, ['fullyequipped'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the word \"fullyequipped\" has a count of 1, even though in the text there is no literal word \"fullyequipped\". This is the result of the preprocessing taken before evaluating word counts, which leads to the removal of the character \"-\" connecting the words \"fully\" and \"equipped\". \n",
     "\n",
-    "ubw_chant = '''I am the Bone of my Sword.\n",
-    "               Steel is My Body and Fire is my Blood. \n",
-    "               I've created over a Thousand Blades, \n",
-    "               Unknown to Death, \n",
-    "               Nor known to Life. \n",
-    "               Have withstood Pain to create many Weapons.\n",
-    "               Yet those Hands will never hold Anything.\n",
-    "               So, as I Pray--\n",
-    "               Unlimited Blade Works.'''\n",
-    "count_keywords(ubw_chant, ['my', 'life', 'Pray', 'i\\'ve'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The function counts these words correctly. Moreover, notice that it forces lower case and ignores punctuation, with the exception of the apostrophes used for sentence contraption. This is because our function first preprocesses the text and the keywords by forcing lower case and removing all punctuation except for the apostrophes when evaluating word counts. This includes cases where a hyphen is used to join two words (ex: to-do is treated as todo). These rules extend to both the text and the keywords:"
+    "Sometimes an user may put in the same word in the keyword list multiple times on accident or by intention. In the output, the count for that word only appears once."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{\"can't\": 1, 'todo': 2}"
+       "{'cozy': 1}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test = 'I can\\'t seem to find the to-do list, cant you help me find the todo list?'\n",
-    "count_keywords(test, ['can\\'t', 'todo'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here we see that the word \"can't\" is treated as a separate word than \"cant\" (a count of 1), whereas \"to-do\" is treated as the same word as \"todo\" (a count of 2).\n",
-    "\n",
-    "If the user were to specify the same word multiple times, the output would only show the count for that word once. The position of this word in the output is determined by that of the word's first appearance in the keyword list:"
+    "review2\n",
+    "count_keywords(review2, ['cozy'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'find': 1, 'phone': 1}"
+       "{'cozy': 1}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "test = 'Where can I find a phone?'\n",
-    "count_keywords(test, ['find', 'phone', 'phonE!', 'phone'])"
+    "review2\n",
+    "count_keywords(review2, ['cozy', 'cozy', 'Cozy', 'cozy!'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another important thing is white space/punctuation only string. Because we evaluate word counts after preprocessing, our function treats these strings as empty:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'': 0}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test = 'abcdefg.'\n",
-    "count_keywords(test, [' ', '', '\\'-['])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We see that even with the presence of an apostrophe, if the string contains only punctuation, if will be treated as an empty string. And since all these three keywords are considered empty strings, the final output only shows the count for empty string once. This is also applicable for the text:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'': 0, 'a': 0, 'b': 0}"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test = '     /....,.!'\n",
-    "count_keywords(test, ['', 'a', 'b'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here the text itself contains only white spaces and punctuation, and therefore the function considers it an empty string, and the function evaluates all counts to be 0, including that of an empty string.\n",
-    "\n",
-    "Finally, a word trapped inside punctuation would be extracted and evaluated as is. This applies to both the text and keywords:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'you': 1}"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "test = '!y-o,u'\n",
-    "count_keywords(test, ['y.o.u!!!!!'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We see that the word \"you\" is trapped within punctuation, but our function takes the alphabets out and pieces the word together."
+    "Notice that punctuation and case do not make a new word. The preprocessing applied to the keywords would map all of them onto the vanilla version of the word."
    ]
   }
  ],

--- a/docs/load_clean_freq_words.ipynb
+++ b/docs/load_clean_freq_words.ipynb
@@ -534,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/test_file.txt
+++ b/test_file.txt
@@ -1,0 +1,1 @@
+Hello, World!


### PR DESCRIPTION
I've completed the doc for the `count_keywords` function. It lives in the `example.ipynb` in the `docs` folder. 