### PR TITLE
fix: Feedback addressed by Orix Au Yeung

### DIFF
--- a/src/wordwright/word_frequency.py
+++ b/src/wordwright/word_frequency.py
@@ -18,7 +18,8 @@ def frequent_words(text, stopwords=[]):
         A Counter object containing the words in the text 
         and their counts, excluding the specified stopwords.
 
-    Example:
+    Example
+    --------
     >>> from wordwright.word_frequency import frequent_words
     >>> text = "The quick brown fox jumps over the lazy dog. The fox was very quick."
     >>> stopwords = ["the", "over", "was", "very"]


### PR DESCRIPTION
The Example section for the function `frequent_words` is not rendering properly on ReadTheDocs. It's been fixed so now it should properly be rendering.