### PR TITLE
fix: Feedback on vignettes addressed by Yi Han

### DIFF
--- a/docs/example.ipynb
+++ b/docs/example.ipynb
@@ -7,17 +7,9 @@
    "source": [
     "# Wordwright Tutorial\n",
     "\n",
-    "## Motivation\n",
-    "In today's world, text is omnipresent and serves as more than just a form of communication. From the briefest tweets to in-depth blog posts, from academic papers to business emails, our digital world is full of textual content. The ability to read, analyze, and derive meaning from the written content is crucial. This is where our text analysis package `wordwright` enters the picture. It efficiently meets professional needs by cleaning text, counting keywords and sentences, identifying language, and ranking word frequency. Whether you are a data scientist, a student, or simply someone curious about text analytics, `wordwright` provides intuitive functions to transform raw text into actionable data."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "bf4b8070-4864-488d-8e90-a70b1dce7076",
-   "metadata": {},
-   "source": [
-    "## Introduction\n",
-    "In this vignette, we demonstrate how `wordwright` can be used to analyze customer reviews similar to those on rental platforms like Airbnb. Such reviews, often submitted post-visit, are useful in helping hosts enhance their accommodations and services, a key aspect of the community ecosystem. These reviews often reveal aspects not covered in descriptions, like bedding comfort or local tips that make a stay special. With `wordwright`, users can efficiently extract key features from these reviews, gaining insights that drive informed decision-making and service improvement.\n",
+    "In today's world, text is omnipresent and serves as more than just a form of communication. From the briefest tweets to in-depth blog posts, from academic papers to business emails, our digital world is full of textual content. The ability to read, analyze, and derive meaning from the written content is crucial.\n",
+    "\n",
+    "In this vignette, we demonstrate how `wordwright` can be used to analyze customer reviews similar to those on rental platforms like Airbnb. Such reviews, often submitted post-visit, are useful in helping hosts enhance their accommodations and services. These reviews often reveal aspects not covered in descriptions, like bedding comfort or local tips that make a stay special. With `wordwright`, users can efficiently extract key features, gaining insights that drive informed decision-making and service improvement.\n",
     "\n",
     "## Imports"
    ]
@@ -43,7 +35,7 @@
    "metadata": {},
    "source": [
     "## Getting Started with Text Files\n",
-    "Before our analysis, we compose several customer reviews and save them as text files for processing."
+    "We compose two customer reviews of varying lengths and details and save them as text files."
    ]
   },
   {
@@ -74,21 +66,10 @@
     "A perfect weekend getaway! Highly recommend!\n",
     "\"\"\"\n",
     "\n",
-    "# A medium length negative review \n",
-    "review3 = \"\"\"Although the location nestled right in the heart of the city, \n",
-    "our stay was marred by disappointment. The first sign of trouble was the linens; \n",
-    "they had a strange, unpleasant smell, as if they hadn't been washed. \n",
-    "The bathroom, too, has a strange odor that made it feel unclean and unpleasant. \n",
-    "Overall, the lack of cleanliness cast a shadow over our visit, \n",
-    "turning our stay into an unpleasant experience. The location, unfortunately, \n",
-    "couldn't make up for these  disappointing aspects.\n",
-    "\"\"\"\n",
-    "\n",
     "# Writing the reviews to text files\n",
-    "filenames = [\"long_pos_review.txt\", \n",
-    "             \"short_pos_review.txt\", \n",
-    "             \"medium_neg_review.txt\"]\n",
-    "reviews = [review1, review2, review3]\n",
+    "filenames = [\"longer_review.txt\",  \n",
+    "             \"shorter_review.txt\"]\n",
+    "reviews = [review1, review2]\n",
     "\n",
     "for filename, review in zip(filenames, reviews):\n",
     "    with open(filename, \"w\") as file:\n",
@@ -97,19 +78,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73b2faad-f1b5-4139-befb-d9b513dee477",
-   "metadata": {},
-   "source": [
-    "Now that we have our text files, let's dive into each function and see how it contributes to our text analysis workflow."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "9434195f-885a-4f62-b45f-6f42cc2075ad",
    "metadata": {},
    "source": [
     "## Function 1: Loading Text Data\n",
-    "The `load_text` function reads the content of a text file without modification. For our customer reviews, we have three different text files containing reviews of varying lengths and details. Now let's load each file, setting the stage for the subsequent cleaning and analyzing processes."
+    "The `load_text` function reads the content of a text file without modification. "
    ]
   },
   {
@@ -139,8 +112,8 @@
     }
    ],
    "source": [
-    "raw_long_pos_review = load_text(\"long_pos_review.txt\")\n",
-    "print(raw_long_pos_review)"
+    "raw_longer_review = load_text(\"longer_review.txt\")\n",
+    "print(raw_longer_review)"
    ]
   },
   {
@@ -161,34 +134,8 @@
     }
    ],
    "source": [
-    "raw_short_pos_review = load_text(\"short_pos_review.txt\")\n",
-    "print(raw_short_pos_review)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "id": "7b9f8fde-af62-4567-a75b-9d3863d81d10",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Although the location nestled right in the heart of the city, \n",
-      "our stay was marred by disappointment. The first sign of trouble was the linens; \n",
-      "they had a strange, unpleasant smell, as if they hadn't been washed. \n",
-      "The bathroom, too, has a strange odor that made it feel unclean and unpleasant. \n",
-      "Overall, the lack of cleanliness cast a shadow over our visit, \n",
-      "turning our stay into an unpleasant experience. The location, unfortunately, \n",
-      "couldn't make up for these  disappointing aspects.\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "raw_medium_neg_review = load_text(\"medium_neg_review.txt\")\n",
-    "print(raw_medium_neg_review)"
+    "raw_shorter_review = load_text(\"shorter_review.txt\")\n",
+    "print(raw_shorter_review)"
    ]
   },
   {
@@ -197,12 +144,12 @@
    "metadata": {},
    "source": [
     "## Function 2: Cleaning the Text\n",
-    "The `clean_text` function removes punctuation and whitespace and converts all words to lowercase, ensuring text is uniform and easier to analyze, especially for word counting and searching (as demonstrated in later sections). This function helps maintain the integrity of our analysis by removing formatting inconsistencies."
+    "The `clean_text` function removes punctuation and whitespace and converts all words to lowercase, removing formatting inconsistencies and ensuring text is uniform for analysis (as demonstrated in later sections)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "3ba7f0bc-f34a-48f1-8107-5b54e0dcef93",
    "metadata": {},
    "outputs": [
@@ -215,8 +162,8 @@
     }
    ],
    "source": [
-    "cleaned_short_pos_review = clean_text(raw_short_pos_review)\n",
-    "print(cleaned_short_pos_review)"
+    "cleaned_shorter_review = clean_text(raw_shorter_review)\n",
+    "print(cleaned_shorter_review)"
    ]
   },
   {
@@ -224,12 +171,12 @@
    "id": "ce017743-93b4-4498-a244-605de4d2e6a0",
    "metadata": {},
    "source": [
-    "Now let's clean the other two reviews. Note that in the reviews shown below, our `clean_text` function also take care to preserve the nuances of the English language. For example, apostrophes that are part of contractions or possessive forms—like in \"hadn't\" or \"city's\"—are maintained. By doing so, our analysis respects the linguistic integrity of the text and retains its original meaning."
+    "Our `clean_text` function preserves the nuances of the English language. For example, apostrophes that are part of contractions or possessive forms—like in \"city's\"—is maintained as shown below. By doing so, our analysis respects the linguistic integrity of the text and retains its original meaning."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "5e6a1d53-a123-422c-a2c6-ceaa055ac9f0",
    "metadata": {},
    "outputs": [
@@ -242,27 +189,8 @@
     }
    ],
    "source": [
-    "cleaned_long_pos_review = clean_text(raw_long_pos_review)\n",
-    "print(cleaned_long_pos_review)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "id": "a60dccfa-b5e5-4cb3-b88b-0d8883f92319",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "although the location nestled right in the heart of the city our stay was marred by disappointment the first sign of trouble was the linens they had a strange unpleasant smell as if they hadn't been washed the bathroom too has a strange odor that made it feel unclean and unpleasant overall the lack of cleanliness cast a shadow over our visit turning our stay into an unpleasant experience the location unfortunately couldn't make up for these disappointing aspects\n"
-     ]
-    }
-   ],
-   "source": [
-    "cleaned_medium_neg_review = clean_text(raw_medium_neg_review)\n",
-    "print(cleaned_medium_neg_review)"
+    "cleaned_longer_review = clean_text(raw_longer_review)\n",
+    "print(cleaned_longer_review)"
    ]
   },
   {
@@ -272,14 +200,14 @@
    "source": [
     "## Function 3: Detecting Language\n",
     "\n",
-    "The `language_detection` function discerns if text is in English. Language detection is a vital feature for global platforms like Airbnb, which receive reviews in multiple languages. Since text analytical tools are typically language-specific, applying an English-focused tool on non-English text can lead to inaccurate results. Hence, segregating reviews by language is fundamental, ensuring customer reviews are both relevant and analytically valuable.\n",
+    "The `language_detection` function discerns if text is in English. Language detection is a vital feature for global platforms like Airbnb, which receive reviews in multiple languages. Since text analytical tools are typically language-specific, applying an English-focused tool on non-English text can lead to inaccurate results.  \n",
     "\n",
-    "This function takes a string as input and assesses its language, returning \"English\" for English text, \"Not English\" for other languages, and \"Language detection error\" in case of detection issues. Upon detecting English, we can proceed with the subsequent text analysis."
+    "This function takes a string as input, returning \"English\" for English text, \"Not English\" for other languages, and \"Language detection error\" in case of detection issues. Upon detecting English, we can proceed with the subsequent text analysis."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "id": "d3a9e062-ea6a-4ae9-b0eb-f3877aa4a335",
    "metadata": {},
    "outputs": [
@@ -289,13 +217,13 @@
        "'English'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "language_detection(raw_short_pos_review)"
+    "language_detection(raw_shorter_review)"
    ]
   },
   {
@@ -308,7 +236,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "id": "71786a97-e820-4bda-82c1-a1228d492860",
    "metadata": {},
    "outputs": [
@@ -318,7 +246,7 @@
        "'Not English'"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -340,14 +268,14 @@
    "source": [
     "## Function 4: Counting Sentences\n",
     "\n",
-    "The `count_sentence` function determines the number of sentences in a given text. In customer reviews, total sentence count serves as a useful measure of customer engagement, with a greater number of sentences typically reflecting deeper interaction. It also helps estimate information density, with higher sentence counts indicating more comprehensive feedback, valuable for service enhancement.\n",
+    "The `count_sentence` function determines the number of sentences in a given text. Total sentence count can serve as a useful measure of customer engagement, with a greater number of sentences typically reflecting deeper interaction. It also helps estimate information density, with higher sentence counts indicating more comprehensive feedback.\n",
     "\n",
     "Specifically, this function enables users to specify punctuation marks—such as periods, exclamation points, and question marks—that indicate sentence breaks, thus determining the total sentence count."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "id": "bbf8c5f1-b6d2-4d0f-a840-3099243bbef2",
    "metadata": {},
    "outputs": [
@@ -361,12 +289,12 @@
    ],
    "source": [
     "#seperate each sentence using period and exclamation mark\n",
-    "customer_1 = count_sentences(raw_long_pos_review, [\".\", \"!\"]) "
+    "customer_1 = count_sentences(raw_longer_review, [\".\", \"!\"]) "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "25af5868-739a-45ad-b8f8-47e0153db359",
    "metadata": {},
    "outputs": [
@@ -380,26 +308,7 @@
    ],
    "source": [
     "#seperate each sentence using period and exclamation mark\n",
-    "customer_2 = count_sentences(raw_short_pos_review, [\".\", \"!\"]) "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "id": "ca1da300-6c13-4864-9c7e-e3f82698fd7f",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "There are 5 sentence(s), which is splited by ['.'].\n"
-     ]
-    }
-   ],
-   "source": [
-    "#seperate each sentence using period\n",
-    "customer_3 = count_sentences(raw_medium_neg_review, [\".\"]) "
+    "customer_2 = count_sentences(raw_shorter_review, [\".\", \"!\"]) "
    ]
   },
   {
@@ -415,7 +324,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "id": "e3ea3867-0b34-48d7-9bca-e9ad0a687c64",
    "metadata": {},
    "outputs": [
@@ -447,13 +356,13 @@
        "         'recommend': 1})"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "frequent_words(raw_short_pos_review)"
+    "frequent_words(raw_shorter_review)"
    ]
   },
   {
@@ -465,12 +374,12 @@
     "In text analysis, the frequency of words can reveal a lot about the content. However, not all words carry the same weight in conveying meaning. This is where the `frequent_words` function becomes particularly valuable.\n",
     "\n",
     "**User-defined Stopwords List**  \n",
-    "Stopwords are commonly used words in any language, like \"the,\" \"is,\" and \"in,\" which may not add significant meaning. The `frequent_words` function, allowing for the removal of user-defined stopwords, focuses on more meaningful words that could provide insights into the text."
+    "Stopwords are commonly used words in any language, like \"the,\" \"is,\" and \"in,\" which may not add significant meaning. The `frequent_words` function, allowing for the removal of user-defined stopwords, focuses on more meaningful words."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "id": "63beee5d-5076-41ae-a8fa-7de902c06f43",
    "metadata": {},
    "outputs": [
@@ -496,7 +405,7 @@
        "         'recommend': 1})"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -504,7 +413,7 @@
    "source": [
     "user_stopwords = [\"the\", \"a\", \"is\", \"was\", \"and\", \"yet\", \"but\", \n",
     "                  \"from\", \"to\", \"in\" \"at\", \"on\"]\n",
-    "frequent_words(raw_short_pos_review, stopwords=user_stopwords)"
+    "frequent_words(raw_shorter_review, stopwords=user_stopwords)"
    ]
   },
   {
@@ -513,12 +422,12 @@
    "metadata": {},
    "source": [
     "**Leveraging NLTK's Comprehensive Stopwords List**  \n",
-    "For a more thorough cleaning of our text data, we can utilize the Natural Language Toolkit (NLTK), a leading package to work with human language data (see details [here](https://www.nltk.org/)). NLTK provides an extensive list of stopwords commonly used in the English language."
+    "For a more thorough cleaning of our text data, we can utilize the Natural Language Toolkit (NLTK)(Loper & Bird 2002), a leading package to work with human language data (see details [here](https://www.nltk.org/)). NLTK provides an extensive list of stopwords commonly used in English."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "id": "129c2064-ad63-400c-a3b0-63fd5796b376",
    "metadata": {},
    "outputs": [],
@@ -532,7 +441,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "id": "3a2fa50d-c7a4-4c03-a13e-ea43fc91329f",
    "metadata": {},
    "outputs": [
@@ -559,13 +468,13 @@
        "         'recommend': 1})"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "frequent_words(raw_short_pos_review, stopwords=nltk_stopwords)"
+    "frequent_words(raw_shorter_review, stopwords=nltk_stopwords)"
    ]
   },
   {
@@ -574,12 +483,12 @@
    "metadata": {},
    "source": [
     "**Extending and Customizing Stopwords List**   \n",
-    "In scenarios where the default NLTK stopwords may not be sufficient for in-depth analysis, users can extend the NLTK stopwords list with their own set of words."
+    "In scenarios where the default NLTK stopwords may not be sufficient, users can extend the NLTK stopwords list with their own set of words."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "id": "ce127457-1159-4e04-8e65-32965acbf8d2",
    "metadata": {},
    "outputs": [
@@ -601,7 +510,7 @@
        "         'recommend': 1})"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -620,7 +529,7 @@
     "custom_stopwords = list(set(custom_stopwords))\n",
     "\n",
     "# Display the most common words excluding the customized stopwords\n",
-    "frequent_words(raw_short_pos_review, stopwords=custom_stopwords)"
+    "frequent_words(raw_shorter_review, stopwords=custom_stopwords)"
    ]
   },
   {
@@ -630,14 +539,12 @@
    "source": [
     "### Displaying the Most Frequent Words\n",
     "The `frequent_words` function returns a `Counter` object (see details [here](https://docs.python.org/3/library/collections.html#collections.Counter)), a specialized dictionary from Python's `collections` module.\n",
-    "One useful method available on a Counter object is `most_common()`(see details of the function [here](https://docs.python.org/3/library/collections.html#collections.Counter.most_common)). This method returns a list of the top N most frequent items and their counts, where N is the number specified by the user.\n",
-    "\n",
-    "This function is particularly handy when dealing with large texts and you want to focus on the most relevant words, such as identifying key themes in customer reviews or the most mentioned terms."
+    "One useful method available on a Counter object is `most_common()`(see details of the function [here](https://docs.python.org/3/library/collections.html#collections.Counter.most_common)). This method returns a list of the top N most frequent items and their counts, where N is the number specified by the user. This function is particularly handy when you want to focus on the most relevant words."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "id": "f85b20bd-ec9c-47f7-8041-ba43fd1b22df",
    "metadata": {},
    "outputs": [
@@ -656,68 +563,16 @@
        " ('amenities', 2)]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "top_10_long_pos_review = frequent_words(raw_long_pos_review, \n",
+    "top_10_long_pos_review = frequent_words(raw_longer_review, \n",
     "                                        stopwords=nltk_stopwords\n",
     "                                       ).most_common(10)\n",
     "top_10_long_pos_review"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "c2ac49c7-48b6-4a10-abd7-cdfda2bb4cc1",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('quiet', 2), ('cozy', 1), ('cottage', 1)]"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "top_3_short_pos_review = frequent_words(raw_short_pos_review, \n",
-    "                                        stopwords=nltk_stopwords\n",
-    "                                       ).most_common(3)\n",
-    "top_3_short_pos_review"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "cb0f313d-ca7d-4d31-adc7-4cf983b8c515",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[('unpleasant', 3),\n",
-       " ('location', 2),\n",
-       " ('stay', 2),\n",
-       " ('strange', 2),\n",
-       " ('although', 1)]"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "top_5_medium_neg_review = frequent_words(raw_medium_neg_review, \n",
-    "                                         stopwords=nltk_stopwords\n",
-    "                                        ).most_common(5)\n",
-    "top_5_medium_neg_review"
    ]
   },
   {
@@ -727,14 +582,12 @@
    "source": [
     "## Function 6: Counting Keywords\n",
     "\n",
-    "The `count_keywords` function searches for specific words in a text, enabling users to check for terms of interest. This feature makes it a practical tool for filtering content. For instance, by identifying the presence and frequency of particular keywords, users can select relevant texts for deeper analysis or exclude those that do not meet their criteria. This function serves as an initial step in sorting content for research, compiling reviews, or simply focusing on the content most relevant to the user's interest.\n",
-    "\n",
-    "This function takes in a list of user-defined keywords and returns the words with their counts in a dictionary object. The `count_keywords` function has a built-in text cleaning feature, eliminating the need for users to pre-clean their text. In other words, the `count_keywords` function simultaneously performs text cleaning and word frequency analysis in a single step."
+    "The `count_keywords` function searches for specific words in a text, serving as a practical tool for filtering content. For instance, by identifying the presence and frequency of particular keywords, users can select relevant texts for deeper analysis or exclude those that do not meet their criteria. The `count_keywords` function has a built-in text cleaning feature, eliminating the need for users to pre-clean their text. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 18,
    "id": "cb5cfc5b-d8ed-4523-bfc3-42310946c81c",
    "metadata": {},
    "outputs": [
@@ -744,13 +597,13 @@
        "{'breathtaking': 2, 'exceptional': 3, \"city's\": 1}"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count_keywords(raw_long_pos_review, \n",
+    "count_keywords(raw_longer_review, \n",
     "               ['breathtaking', 'exceptional', 'city\\'s']\n",
     "              )"
    ]
@@ -760,12 +613,12 @@
    "id": "2c508a71-1152-46f6-ae8f-a9964c3a7c2b",
    "metadata": {},
    "source": [
-    "**Critical Remark**: by integrating all features in the `clean_text` function, the `count_keywords` function forces lower case and ignores punctuation, including cases where a hyphen is used to join two words. For instance, the word \"fully-equipped\" is treated as \"fullyequipped\". These rules apply to both the text and the specified keywords. In this instance, \"fullyequipped\" has a count of 1, despite its absence in the text as a literal word. This outcome stems from the preprocessing step, where the hyphen \"-\" between \"fully\" and \"equipped\" is removed, merging the two words into one."
+    "**Critical Remark**: by integrating all features in the `clean_text` function, the `count_keywords` function forces lower case and ignores punctuation. For instance, the word \"fully-equipped\" is treated as \"fullyequipped\". These rules apply to both the text and the specified keywords. In this instance, \"fullyequipped\" has a count of 1, despite its absence in the text as a literal word. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 19,
    "id": "354d3932-50e3-4bb1-aa41-3a3cc7624dbe",
    "metadata": {},
    "outputs": [
@@ -775,18 +628,18 @@
        "{'fullyequipped': 1}"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count_keywords(raw_long_pos_review, ['fullyequipped'])"
+    "count_keywords(raw_longer_review, ['fullyequipped'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 20,
    "id": "1ca25b70-3e77-40cf-9a26-c4971297b665",
    "metadata": {},
    "outputs": [
@@ -796,13 +649,13 @@
        "{'fullyequipped': 1}"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count_keywords(raw_long_pos_review, ['fully-equipped'])"
+    "count_keywords(raw_longer_review, ['fully-equipped'])"
    ]
   },
   {
@@ -810,12 +663,12 @@
    "id": "3ea08415-59a3-45c8-9db6-30012d095c57",
    "metadata": {},
    "source": [
-    "**Robustness**: The `count_keywords` function is designed with robustness. Even if a user-defined keyword is accidentally repeated, capitalized, or entered with extra punctuation, the function resolves these variations and provides a singular count. As above-mentioned, the function's pre-processing converts all keywords to their base form, ensuring that the analysis is more resilient to user input variations."
+    "**Robustness**: The `count_keywords` function is designed with robustness. Even if a user-defined keyword is accidentally repeated, capitalized, or entered with extra punctuation, the function resolves these variations and provides a singular count, which ensures the analysis is more resilient to user inputs."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 21,
    "id": "759cc4af-1b09-4906-95ac-8acde9c05740",
    "metadata": {},
    "outputs": [
@@ -825,18 +678,18 @@
        "{'cozy': 1}"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count_keywords(raw_short_pos_review, ['cozy'])"
+    "count_keywords(raw_shorter_review, ['cozy'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 22,
    "id": "f8318bea-1ae6-493e-801c-321d2d5601a8",
    "metadata": {},
    "outputs": [
@@ -846,13 +699,23 @@
        "{'cozy': 1}"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "count_keywords(raw_short_pos_review, ['cozy', 'cozy', 'Cozy', 'cozy!'])"
+    "count_keywords(raw_shorter_review, ['cozy', 'cozy', 'Cozy', 'cozy!'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80194eca-f5b1-4bdc-b0ad-1c37a784e2f7",
+   "metadata": {},
+   "source": [
+    "## Reference\n",
+    "\n",
+    "Loper, E., & Bird, S. (2002). Nltk: The natural language toolkit. arXiv preprint cs/0205028."
    ]
   }
  ],


### PR DESCRIPTION
- We have removed one review; however we decided to keep the other two reviews in the vignette as they serve for different purposes and can also serve as a contrast to illustrate the utility of our function.

- We have removed one review and we have shoreten our explanation substantially to keep the vignette more concise.

- We have removed section links "introduction" and "motivation". However we decided to keep "import" and "getting started with text files" since they are independent sections and serve for specific purposes.

- reference has been added

